### PR TITLE
e2e: test pod mutation

### DIFF
--- a/test/e2e/bindata/assets/306_anonymous_cr.yaml
+++ b/test/e2e/bindata/assets/306_anonymous_cr.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: runoncedurationoverride-anonymous-access
+rules:
+  - apiGroups:
+      - "admission.apps.openshift.io"
+    resources:
+      - "runoncedurationoverrides"
+    verbs:
+      - create
+      - get

--- a/test/e2e/bindata/assets/307_anonymous_crb.yaml
+++ b/test/e2e/bindata/assets/307_anonymous_crb.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: runoncedurationoverride-anonymous-access
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: runoncedurationoverride-anonymous-access
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: User
+    name: system:anonymous


### PR DESCRIPTION
To test `.ActiveDeadlineSeconds` field gets overriden.