### PR TITLE
Add test case for not mutating when restartPolicy is Always

### DIFF
--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -313,6 +313,85 @@ func TestMutation(t *testing.T) {
 
 }
 
+func TestNotMutation(t *testing.T) {
+	// runoncedurationoverrides.admission.apps.openshift.io/enabled: "true"
+	ctx, cancelFnc := context.WithCancel(context.TODO())
+	defer cancelFnc()
+
+	clientSet := getKubeClientOrDie()
+
+	testNamespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "e2e-" + strings.ToLower(t.Name()),
+			Labels: map[string]string{
+				"runoncedurationoverrides.admission.apps.openshift.io/enabled": "true",
+			},
+		},
+	}
+	if _, err := clientSet.CoreV1().Namespaces().Create(ctx, testNamespace, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Unable to create ns %v", testNamespace.Name)
+	}
+	defer clientSet.CoreV1().Namespaces().Delete(ctx, testNamespace.Name, metav1.DeleteOptions{})
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace.Name,
+			Name:      "test-mutating-admission-pod",
+		},
+		Spec: corev1.PodSpec{
+			SecurityContext: &corev1.PodSecurityContext{
+				RunAsNonRoot: utilpointer.BoolPtr(true),
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
+			},
+			Containers: []corev1.Container{{
+				SecurityContext: &corev1.SecurityContext{
+					AllowPrivilegeEscalation: utilpointer.BoolPtr(false),
+					Capabilities: &corev1.Capabilities{
+						Drop: []corev1.Capability{
+							"ALL",
+						},
+					},
+				},
+				Name:            "pause",
+				ImagePullPolicy: "Always",
+				Image:           "kubernetes/pause",
+				Ports:           []corev1.ContainerPort{{ContainerPort: 80}},
+			}},
+			RestartPolicy: corev1.RestartPolicyAlways,
+		},
+	}
+
+	if _, err := clientSet.CoreV1().Pods(pod.Namespace).Create(ctx, pod, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Unable to create a pod: %v", err)
+	}
+
+	if err := wait.PollImmediate(1*time.Second, time.Minute, func() (bool, error) {
+		klog.Infof("Listing pods...")
+		pod, err := clientSet.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
+		if err != nil {
+			klog.Errorf("Unable to get pod: %v", err)
+			return false, nil
+		}
+		if pod.Spec.NodeName == "" {
+			klog.Infof("Pod not yet assigned to a node")
+			return false, nil
+		}
+		klog.Infof("Pod successfully assigned to a node: %v", pod.Spec.NodeName)
+
+		if pod.Spec.ActiveDeadlineSeconds != nil && *pod.Spec.ActiveDeadlineSeconds == 3600 {
+			klog.Infof("pod.Spec.ActiveDeadlineSeconds is set to 3600, even though restartPolicy is Always")
+			return false, nil
+		}
+
+		return true, nil
+	}); err != nil {
+		t.Fatalf("Unable to wait for a scheduled pod: %v", err)
+	}
+
+}
+
 func getKubeClientOrDie() *k8sclient.Clientset {
 	kubeconfig := os.Getenv("KUBECONFIG")
 	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)


### PR DESCRIPTION
This PR adds a new test case to assure that when pod's restartPolicy is Always,
ActiveDeadlineSeconds field is not set by webhook.