### PR TITLE
Rename APIGroup

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ for a pod with `RestartPolicy` set to `Never` or `OnFailure`. The so called run-
    $ oc create ns test
    ```
 
-1. Label the namespace with `runoncedurationoverrides.admission.apps.openshift.io/enabled: "true"`
+1. Label the namespace with `runoncedurationoverrides.admission.runoncedurationoverride.openshift.io/enabled: "true"`
    ```
-   $ oc label ns test runoncedurationoverrides.admission.apps.openshift.io/enabled=true
+   $ oc label ns test runoncedurationoverrides.admission.runoncedurationoverride.openshift.io/enabled=true
    ```
 
 1. Create a testing pod in the namespace with RestartPolicy set to Never. E.g.

--- a/artifacts/manifests/301_anonymous_rbac.yaml
+++ b/artifacts/manifests/301_anonymous_rbac.yaml
@@ -4,7 +4,7 @@ metadata:
   name: runoncedurationoverride-anonymous-access
 rules:
   - apiGroups:
-      - "admission.apps.openshift.io"
+      - "admission.runoncedurationoverride.openshift.io"
     resources:
       - "runoncedurationoverrides"
     verbs:

--- a/artifacts/manifests/600_mutating.yaml
+++ b/artifacts/manifests/600_mutating.yaml
@@ -1,21 +1,21 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: runoncedurationoverrides.admission.apps.openshift.io
+  name: runoncedurationoverrides.admission.runoncedurationoverride.openshift.io
   labels:
     runoncedurationoverride: "true"
 webhooks:
-  - name: runoncedurationoverrides.admission.apps.openshift.io
+  - name: runoncedurationoverrides.admission.runoncedurationoverride.openshift.io
     namespaceSelector:
       matchLabels:
-        runoncedurationoverrides.admission.apps.openshift.io/enabled: "true"
+        runoncedurationoverrides.admission.runoncedurationoverride.openshift.io/enabled: "true"
       matchExpressions:
         - key: runlevel
           operator: NotIn
           values: ["0","1"]
     matchPolicy: Equivalent
     clientConfig:
-      url: https://localhost:9400/apis/admission.apps.openshift.io/v1/runoncedurationoverrides
+      url: https://localhost:9400/apis/admission.runoncedurationoverride.openshift.io/v1/runoncedurationoverrides
       caBundle: SERVICE_SERVING_CERT_CA
     rules:
       - operations:

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -1,6 +1,6 @@
 package api
 
 const (
-	Group   = "admission.apps.openshift.io"
+	Group   = "admission.runoncedurationoverride.openshift.io"
 	Version = "v1"
 )

--- a/test/e2e/bindata/assets/306_anonymous_cr.yaml
+++ b/test/e2e/bindata/assets/306_anonymous_cr.yaml
@@ -4,7 +4,7 @@ metadata:
   name: runoncedurationoverride-anonymous-access
 rules:
   - apiGroups:
-      - "admission.apps.openshift.io"
+      - "admission.runoncedurationoverride.openshift.io"
     resources:
       - "runoncedurationoverrides"
     verbs:

--- a/test/e2e/bindata/assets/600_mutating.yaml
+++ b/test/e2e/bindata/assets/600_mutating.yaml
@@ -1,21 +1,21 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: runoncedurationoverrides.admission.apps.openshift.io
+  name: runoncedurationoverrides.admission.runoncedurationoverride.openshift.io
   labels:
     runoncedurationoverride: "true"
 webhooks:
-  - name: runoncedurationoverrides.admission.apps.openshift.io
+  - name: runoncedurationoverrides.admission.runoncedurationoverride.openshift.io
     namespaceSelector:
       matchLabels:
-        runoncedurationoverrides.admission.apps.openshift.io/enabled: "true"
+        runoncedurationoverrides.admission.runoncedurationoverride.openshift.io/enabled: "true"
       matchExpressions:
         - key: runlevel
           operator: NotIn
           values: ["0","1"]
     matchPolicy: Equivalent
     clientConfig:
-      url: https://localhost:9400/apis/admission.apps.openshift.io/v1/runoncedurationoverrides
+      url: https://localhost:9400/apis/admission.runoncedurationoverride.openshift.io/v1/runoncedurationoverrides
       caBundle: "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURtVENDQW9HZ0F3SUJBZ0lVR1d0Ykx4Z0Q5WGl4azNNQ0lPUTAwcjN5VExVd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1hERUxNQWtHQTFVRUJoTUNlSGd4Q2pBSUJnTlZCQWdNQVhneENqQUlCZ05WQkFjTUFYZ3hDakFJQmdOVgpCQW9NQVhneENqQUlCZ05WQkFzTUFYZ3hDekFKQmdOVkJBTU1BbU5oTVJBd0RnWUpLb1pJaHZjTkFRa0JGZ0Y0Ck1CNFhEVEl6TURFeU16RTBNVFF6TTFvWERUSTBNREV5TXpFME1UUXpNMW93WERFTE1Ba0dBMVVFQmhNQ2VIZ3gKQ2pBSUJnTlZCQWdNQVhneENqQUlCZ05WQkFjTUFYZ3hDakFJQmdOVkJBb01BWGd4Q2pBSUJnTlZCQXNNQVhneApDekFKQmdOVkJBTU1BbU5oTVJBd0RnWUpLb1pJaHZjTkFRa0JGZ0Y0TUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGCkFBT0NBUThBTUlJQkNnS0NBUUVBcjJabzRHaTNCakw0NWt1UHVCT3JadHZZR1VUcy9mVjlUaEZObjNjeGxSWlUKMHZHNVRvd092cUtMVmFZaFUzWVQ2VEE5UFBRMmg1ZWUrU3o1TDF5TzBvMVlzbzJRT2dFZ3ZjVTAvTkpDaDFGTApQc1BCR05EMmJmNTUzQUlFK29OVXZqT01laGV2RUdVRGNIUUs3L01ReERQSVVKeFFJUHlFb2Q3OXA2azlYRVpHCmFVb3Y3b09KZjFsSlhGdDVqRDFONlRncjMzZktoRDQ0NDR1WmtDZDZmT1IwcU9pTjRWYzB5WFJiSHAyeXRVa2EKcTUvSHZKcU9ubTY0bThWQk95bFByTGtiZC9EM2RmNFNuUDhLVjdiNVpzU3hKb0FoeGVraENUbzJYYURwYTFrWAo1V1BURlR4Q2h6L0VxZFNTT2k3UmFqL0d4ZmVkQTIxVWdqM1IxZWU5SXdJREFRQUJvMU13VVRBZEJnTlZIUTRFCkZnUVU3WFpXME5qMzFSa09ZUXNtT0tXU0RCTzJSSW93SHdZRFZSMGpCQmd3Rm9BVTdYWlcwTmozMVJrT1lRc20KT0tXU0RCTzJSSW93RHdZRFZSMFRBUUgvQkFVd0F3RUIvekFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBQUliUAp5dGF0Q2ZHS0hROFZFTzIxWXVwTThnL2dqQ0FGbEdEeHIrdlhWSERvaVVMdE5uMHVvTWRMa2VjY3FGc3VidkFXClZXREplWkVwWjJlV3Y1QWhLbmdNa0tHYkRpTW5ZU29YUENmVkFyL2tYOFNHNHRyM2EvUGg1c2w2c1drcm9QcHoKdVQrRTRCOXZOaDk1MmZHQUNzSlFBZ2RpaThGRGpFZks1Wnl3MXdmblplaVBDSGR1UG84MDhmZmxYbzZ5eExuQgpJMkE4UGlHZk9FeEFXTEIvZHNQS1Z0QVg2VkcyaEl4TDV4dDVXMjBEdUNHRjhaNGpqdnBjcHkxWVRuVFFrZ0dDCkkxaytYZkxNd0pVQTNYU1FpTCs1TVRxcmRZUlJUZjJLdHp2bGU1Zmk2ZEJaYWZwU3V6RTFVNzNYa251RlZVNlUKL3VvVmFtVUtNYjhaU3E4dGVRPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo="
     rules:
       - operations:

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -233,7 +233,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestMutation(t *testing.T) {
-	// runoncedurationoverrides.admission.apps.openshift.io/enabled: "true"
+	// runoncedurationoverrides.admission.runoncedurationoverride.openshift.io/enabled: "true"
 	ctx, cancelFnc := context.WithCancel(context.TODO())
 	defer cancelFnc()
 
@@ -243,7 +243,7 @@ func TestMutation(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "e2e-" + strings.ToLower(t.Name()),
 			Labels: map[string]string{
-				"runoncedurationoverrides.admission.apps.openshift.io/enabled": "true",
+				"runoncedurationoverrides.admission.runoncedurationoverride.openshift.io/enabled": "true",
 			},
 		},
 	}
@@ -314,7 +314,7 @@ func TestMutation(t *testing.T) {
 }
 
 func TestNotMutation(t *testing.T) {
-	// runoncedurationoverrides.admission.apps.openshift.io/enabled: "true"
+	// runoncedurationoverrides.admission.runoncedurationoverride.openshift.io/enabled: "true"
 	ctx, cancelFnc := context.WithCancel(context.TODO())
 	defer cancelFnc()
 
@@ -324,7 +324,7 @@ func TestNotMutation(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "e2e-" + strings.ToLower(t.Name()),
 			Labels: map[string]string{
-				"runoncedurationoverrides.admission.apps.openshift.io/enabled": "true",
+				"runoncedurationoverrides.admission.runoncedurationoverride.openshift.io/enabled": "true",
 			},
 		},
 	}


### PR DESCRIPTION
This PR renames APIGroup from `admission.apps.openshift.io` to `admission.runoncedurationoverride.openshift.io`