### PR TITLE
Fix command to get activeDeadlineSeconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,6 @@ for a pod with `RestartPolicy` set to `Never` or `OnFailure`. The so called run-
 
 1. Checking the `.spec.activeDeadlineSeconds` field was set to 3600:
    ```sh
-   $ oc get pods -n test -o json | jq '.items[0].spec.activeDeadlineSeconds'
+   $ oc get pods -n test -o json | jq '.spec.activeDeadlineSeconds'
    3600
    ```


### PR DESCRIPTION
With the current command users will not be able to get activeDeadlineSeconds that was set on the pod. Fixing the same in the PR here.